### PR TITLE
docstrings

### DIFF
--- a/section5/docstrings.py
+++ b/section5/docstrings.py
@@ -1,0 +1,15 @@
+def example_func(param1, param2):
+    """Example function with types documented in the docstring.
+    
+    Args:
+        param1 (int): The first parameter.
+        param2 (str): The second parameter.
+        
+    Returns:
+        bool: The return value. True for success, False otherwise.
+    """
+    print(param1)
+    print(param2)
+    return True
+
+print(example_func.__doc__)   # ドキュメンテーション文字列を表示する


### PR DESCRIPTION
関数名.__doc__で関数内の""""""で括ったコメント（関数の説明）を表示できる