### PR TITLE
importエラー

### DIFF
--- a/section6/import_error.py
+++ b/section6/import_error.py
@@ -1,0 +1,6 @@
+try:
+    from lesson_package import utils
+except ImportError:
+    from lesson_package.tools import utils
+
+print(utils.say_twice('word'))


### PR DESCRIPTION
古いパッケージでも新しいパッケージでもどちらでもいいようにする場合に、try except ImportErrorが使われる
